### PR TITLE
Fixes hang in curl to elasticsearch

### DIFF
--- a/tools/tools.py
+++ b/tools/tools.py
@@ -77,7 +77,7 @@ class Tools:
         return connection_ok
 
     def index_template(self):
-        out = subprocess.check_output(['curl -XHEAD -i "elasticsearch:9200/_template/aws_billing"'], shell=True, stderr=subprocess.PIPE)
+        out = subprocess.check_output(['curl --head "elasticsearch:9200/_template/aws_billing"'], shell=True, stderr=subprocess.PIPE)
         if '200 OK' not in out:
             status = subprocess.Popen(
                 ['curl -XPUT elasticsearch:9200/_template/aws_billing -d "`cat /aws-elk-billing/aws-billing-es-template.json`"'],


### PR DESCRIPTION
A call to `curl -XHEAD -i elastic...` hangs avoiding to process the billing logs.

Fixes #17 
