### PR TITLE
Fix MONTHNUM unable to match months > 9

### DIFF
--- a/logstash.conf
+++ b/logstash.conf
@@ -8,7 +8,7 @@ input {
 filter {
   if [type] == "aws_billing_hourly" or [type] == "aws_billing_monthly" {
     grok {
-         match => { "lineItem/UsageStartDate" => "%{YEAR:billing_year}-%{MONTHNUM:billing_month}" }
+         match => { "lineItem/UsageStartDate" => "%{YEAR:billing_year}-%{MONTHNUM2:billing_month}" }
     }
 
     mutate {


### PR DESCRIPTION
Issue with MONTHNUM value used by GROK parser for logstash.

Using MONTHNUM2 parses dates 01..09,10..12 correctly according to https://github.com/logstash-plugins/logstash-patterns-core/blob/master/patterns/grok-patterns

Fixes #21 