### PR TITLE
Prevent aws-elk-billing from exiting once /sbin/init is done

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ WORKDIR /aws-elk-billing
 ENV TZ=Asia/Kolkata
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-CMD ["/sbin/init"]
+ENTRYPOINT ["/sbin/init"]

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -42,8 +42,3 @@ if __name__ == '__main__':
 
     # delete the intermediate files
     tools.delete_csv_json_files()
-
-    # /sbin/init is not working so used this loop to keep the docker up, Have to change it!
-    while(True):
-        pass
-


### PR DESCRIPTION
Running the tool had a 100% CPU usage on a core from the orchestrate.py script and it's infinite loop. 

In this PR, i removed said loop and changed `CMD` to `ENTRYPOINT` on the Dockerfile to prevent the container from exiting